### PR TITLE
Add user details to website

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,8 +5,9 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Your Name | Personal Website",
-  description: "Personal website showcasing my professional experience, skills, and projects",
+  title: "Mauricio Javier Letort | Personal Website",
+  description:
+    "Personal website showcasing my professional experience, skills, and projects",
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 export default function Home() {
   return (
     <main className="min-h-screen">
@@ -7,10 +5,11 @@ export default function Home() {
       <nav className="fixed w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm z-50 border-b border-gray-200 dark:border-gray-800">
         <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between h-16 items-center">
-            <div className="text-xl font-bold">Your Name</div>
+            <div className="text-xl font-bold">Mauricio Javier Letort</div>
             <div className="hidden md:flex space-x-8">
               <a href="#about" className="hover:text-blue-600 dark:hover:text-blue-400">About</a>
               <a href="#experience" className="hover:text-blue-600 dark:hover:text-blue-400">Experience</a>
+              <a href="#education" className="hover:text-blue-600 dark:hover:text-blue-400">Education</a>
               <a href="#skills" className="hover:text-blue-600 dark:hover:text-blue-400">Skills</a>
               <a href="#projects" className="hover:text-blue-600 dark:hover:text-blue-400">Projects</a>
               <a href="#contact" className="hover:text-blue-600 dark:hover:text-blue-400">Contact</a>
@@ -24,10 +23,10 @@ export default function Home() {
         <div className="max-w-5xl mx-auto">
           <div className="text-center">
             <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold mb-6">
-              Hi, I'm <span className="text-blue-600 dark:text-blue-400">Your Name</span>
+              Hi, I&apos;m <span className="text-blue-600 dark:text-blue-400">Mauricio Javier Letort</span>
             </h1>
             <p className="text-xl sm:text-2xl text-gray-600 dark:text-gray-300 mb-8">
-              Your Professional Title
+              Junior Programmer
             </p>
             <div className="flex justify-center space-x-4">
               <a href="#contact" className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition">
@@ -41,6 +40,8 @@ export default function Home() {
         </div>
       </section>
 
+
+
       {/* About Section */}
       <section id="about" className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-800">
         <div className="max-w-5xl mx-auto">
@@ -51,7 +52,7 @@ export default function Home() {
                 Write your compelling introduction here. Describe your passion, what drives you, and what makes you unique in your field.
               </p>
               <p className="text-gray-600 dark:text-gray-300">
-                Add more details about your background, interests, and what you're looking to achieve in your career.
+                Add more details about your background, interests, and what you&apos;re looking to achieve in your career.
               </p>
             </div>
             <div className="relative h-64 md:h-96">
@@ -69,16 +70,59 @@ export default function Home() {
           <div className="space-y-8">
             {/* Experience Item */}
             <div className="border-l-4 border-blue-600 pl-4">
-              <h3 className="text-xl font-bold">Job Title</h3>
-              <p className="text-blue-600 dark:text-blue-400">Company Name</p>
-              <p className="text-gray-600 dark:text-gray-400">2020 - Present</p>
+              <h3 className="text-xl font-bold">Junior Programmer</h3>
+              <p className="text-blue-600 dark:text-blue-400">Robalino Law – Quito, Ecuador</p>
+              <p className="text-gray-600 dark:text-gray-400">07/2024 – 08/2024</p>
               <ul className="list-disc list-inside mt-2 text-gray-600 dark:text-gray-300">
-                <li>Key achievement or responsibility</li>
-                <li>Another significant accomplishment</li>
-                <li>Notable project or contribution</li>
+                <li>Worked on the BIPAT (Business Intelligence Process Automated Technology) team creating solutions for the firm’s clients.</li>
+                <li>Worked in some team projects simultaneously and created scripts in Python for the clients’ solutions.</li>
               </ul>
             </div>
-            {/* Add more experience items as needed */}
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="text-xl font-bold">Supplier Database</h3>
+              <p className="text-blue-600 dark:text-blue-400">San Jose de Puembo Hotel and Conference Center, an Ascend Hotel Collection – Quito, Ecuador</p>
+              <p className="text-gray-600 dark:text-gray-400">07/2023 – 08/2023</p>
+              <ul className="list-disc list-inside mt-2 text-gray-600 dark:text-gray-300">
+                <li>Contacted and researched information regarding each vendor to build a complete database for all the hotel suppliers.</li>
+                <li>Analyzed the profitability of each client.</li>
+              </ul>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="text-xl font-bold">Design Specialist</h3>
+              <p className="text-blue-600 dark:text-blue-400">Grupo Más – Quito, Ecuador</p>
+              <p className="text-gray-600 dark:text-gray-400">06/2023 – 07/2023</p>
+              <ul className="list-disc list-inside mt-2 text-gray-600 dark:text-gray-300">
+                <li>Created and planned the front-end of an app design to help in parking solutions.</li>
+                <li>Used the Justinmind software for the prototyping of the app.</li>
+              </ul>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="text-xl font-bold">Volunteering Co-Founder</h3>
+              <p className="text-blue-600 dark:text-blue-400">English for Puembo – Quito, Ecuador</p>
+              <p className="text-gray-600 dark:text-gray-400">07/2022 – 12/2022</p>
+              <ul className="list-disc list-inside mt-2 text-gray-600 dark:text-gray-300">
+                <li>Co-founded a volunteering program with Colegio Menor students to help underprivileged children learn English.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Education Section */}
+      <section id="education" className="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50 dark:bg-gray-800">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold mb-8">Education</h2>
+          <div className="space-y-8">
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="text-xl font-bold">McGill University</h3>
+              <p className="text-blue-600 dark:text-blue-400">B.Sc. Computer Science – Artificial Intelligence, Minor in Entrepreneurship</p>
+              <p className="text-gray-600 dark:text-gray-400">09/2022 – 05/2026 | Montreal, Canada</p>
+            </div>
+            <div className="border-l-4 border-blue-600 pl-4">
+              <h3 className="text-xl font-bold">Colegio Menor San Francisco de Quito</h3>
+              <p className="text-blue-600 dark:text-blue-400">Magna Cum Laude – 93.34 GPA</p>
+              <p className="text-gray-600 dark:text-gray-400">06/2022 | Quito, Ecuador</p>
+            </div>
           </div>
         </div>
       </section>
@@ -90,14 +134,26 @@ export default function Home() {
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
             {/* Skill Item */}
             <div className="bg-white dark:bg-gray-700 p-4 rounded-lg shadow">
-              <h3 className="font-bold mb-2">Skill Category</h3>
+              <h3 className="font-bold mb-2">Programming</h3>
               <ul className="text-gray-600 dark:text-gray-300">
-                <li>Skill 1</li>
-                <li>Skill 2</li>
-                <li>Skill 3</li>
+                <li>Python</li>
+                <li>C</li>
+                <li>Java</li>
+                <li>Bash</li>
+                <li>Command-Line Interface</li>
+                <li>Assembler</li>
+                <li>Logisim</li>
+                <li>OCaml</li>
               </ul>
             </div>
-            {/* Add more skill categories as needed */}
+            <div className="bg-white dark:bg-gray-700 p-4 rounded-lg shadow">
+              <h3 className="font-bold mb-2">Languages</h3>
+              <ul className="text-gray-600 dark:text-gray-300">
+                <li>Spanish: Native</li>
+                <li>English: Fluent</li>
+                <li>French: Basic</li>
+              </ul>
+            </div>
           </div>
         </div>
       </section>
@@ -111,17 +167,30 @@ export default function Home() {
             <div className="bg-white dark:bg-gray-700 rounded-lg shadow overflow-hidden">
               <div className="h-48 bg-gray-200 dark:bg-gray-600"></div>
               <div className="p-6">
-                <h3 className="text-xl font-bold mb-2">Project Name</h3>
+                <h3 className="text-xl font-bold mb-2">Virtual Coin Transaction Program</h3>
                 <p className="text-gray-600 dark:text-gray-300 mb-4">
-                  Brief description of the project and your role in it.
+                  Developed a program in Python that allows users to transfer coins to each other using an API to request user information.
                 </p>
-                <div className="flex space-x-4">
-                  <a href="#" className="text-blue-600 dark:text-blue-400 hover:underline">View Project</a>
-                  <a href="#" className="text-blue-600 dark:text-blue-400 hover:underline">Source Code</a>
-                </div>
               </div>
             </div>
-            {/* Add more project cards as needed */}
+            <div className="bg-white dark:bg-gray-700 rounded-lg shadow overflow-hidden">
+              <div className="h-48 bg-gray-200 dark:bg-gray-600"></div>
+              <div className="p-6">
+                <h3 className="text-xl font-bold mb-2">Instagram Database Program</h3>
+                <p className="text-gray-600 dark:text-gray-300 mb-4">
+                  CLI application written in C to manage an Instagram database using dynamic arrays, custom structs and UNIX Epoch timestamps.
+                </p>
+              </div>
+            </div>
+            <div className="bg-white dark:bg-gray-700 rounded-lg shadow overflow-hidden">
+              <div className="h-48 bg-gray-200 dark:bg-gray-600"></div>
+              <div className="p-6">
+                <h3 className="text-xl font-bold mb-2">Mini-MIPS CPU</h3>
+                <p className="text-gray-600 dark:text-gray-300 mb-4">
+                  Designed a single-cycle MIPS CPU in Logisim implementing instructions such as load, save, add, subtract and halt.
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </section>
@@ -133,20 +202,30 @@ export default function Home() {
           <div className="grid md:grid-cols-2 gap-8">
             <div>
               <p className="text-gray-600 dark:text-gray-300 mb-4">
-                I'm always open to new opportunities and collaborations. Feel free to reach out!
+                I&apos;m always open to new opportunities and collaborations. Feel free to reach out!
               </p>
               <div className="space-y-4">
                 <p className="flex items-center">
                   <span className="mr-2">📧</span>
-                  your.email@example.com
+                  mjletort@gmail.com
                 </p>
                 <p className="flex items-center">
                   <span className="mr-2">📱</span>
-                  Your Phone Number
+                  (438) 979 4330
                 </p>
                 <p className="flex items-center">
                   <span className="mr-2">📍</span>
-                  Your Location
+                  1430 City Councillors St, Montreal, Canada
+                </p>
+                <p className="flex items-center">
+                  <span className="mr-2">🔗</span>
+                  <a href="https://linkedin.com/in/mauricio-letort-129b30258" className="hover:underline">
+                    linkedin.com/in/mauricio-letort-129b30258
+                  </a>
+                </p>
+                <p className="flex items-center">
+                  <span className="mr-2">🌐</span>
+                  French Nationality
                 </p>
               </div>
             </div>
@@ -177,7 +256,7 @@ export default function Home() {
       <footer className="py-8 px-4 sm:px-6 lg:px-8 border-t border-gray-200 dark:border-gray-800">
         <div className="max-w-5xl mx-auto text-center">
           <p className="text-gray-600 dark:text-gray-400">
-            © {new Date().getFullYear()} Your Name. All rights reserved.
+            © {new Date().getFullYear()} Mauricio Javier Letort. All rights reserved.
           </p>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- update site metadata with the user's name
- insert real navigation labels, hero text, contact info
- add user experience, education, skills, and project sections
- include LinkedIn and nationality in contact info

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855b9615848832fa9a8311bd43b3c0b